### PR TITLE
Add admin dropdown menu

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,11 +1,24 @@
 <div class="container my-4">
   <h1>{{ title }}</h1>
+
+  <nav class="mb-3">
+    <ul class="nav">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">Administración</a>
+        <ul class="dropdown-menu">
+          <li><a class="dropdown-item" href="#grupos">Grupos</a></li>
+          <li><a class="dropdown-item" href="#usuarios">Usuarios</a></li>
+        </ul>
+      </li>
+    </ul>
+  </nav>
+
   <div class="row">
-    <div class="col-md-6">
+    <div id="usuarios" class="col-md-6">
       <app-user-form (refresh)="userList.getUsers()"></app-user-form>
       <app-user-list #userList></app-user-list>
     </div>
-    <div class="col-md-6">
+    <div id="grupos" class="col-md-6">
       <app-group-form (refresh)="groupList.getGroups()"></app-group-form>
       <app-group-list #groupList></app-group-list>
     </div>

--- a/src/index.html
+++ b/src/index.html
@@ -9,5 +9,6 @@
 </head>
 <body>
   <app-root></app-root>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add admin dropdown navigation menu below the page header
- link to groups and users sections
- load Bootstrap JavaScript

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6844fcf87048832f9b9a01eca418b836