### PR TITLE
Add alumno and profesor CRUD

### DIFF
--- a/src/app/alumnos/alumno-form.component.html
+++ b/src/app/alumnos/alumno-form.component.html
@@ -1,0 +1,38 @@
+<div class="card shadow mb-4">
+  <div class="card-header py-3">
+    <h6 class="m-0 font-weight-bold text-primary">
+      {{ editId ? 'Editar Alumno' : 'Agregar Alumno' }}
+    </h6>
+  </div>
+  <div class="card-body">
+    <form (ngSubmit)="submit()" class="mb-3">
+      <div class="mb-2">
+        <label class="form-label">Nombre</label>
+        <input class="form-control" [(ngModel)]="dto.nombre" name="nombre" placeholder="Nombre del alumno" required
+               [ngClass]="{ 'is-invalid': errors['nombre'] }">
+        <div *ngIf="errors['nombre']" class="invalid-feedback">
+          {{ errors['nombre'] }}
+        </div>
+      </div>
+      <div class="mb-2">
+        <label class="form-label">Apellido</label>
+        <input class="form-control" [(ngModel)]="dto.apellido" name="apellido" placeholder="Apellido del alumno" required
+               [ngClass]="{ 'is-invalid': errors['apellido'] }">
+        <div *ngIf="errors['apellido']" class="invalid-feedback">
+          {{ errors['apellido'] }}
+        </div>
+      </div>
+      <div class="mb-2">
+        <label class="form-label">Foto de Perfil</label>
+        <input class="form-control" [(ngModel)]="dto.fotoPerfil" name="fotoPerfil" placeholder="URL de la foto" required
+               [ngClass]="{ 'is-invalid': errors['fotoPerfil'] }">
+        <div *ngIf="errors['fotoPerfil']" class="invalid-feedback">
+          {{ errors['fotoPerfil'] }}
+        </div>
+      </div>
+      <button type="submit" class="btn btn-primary">
+        {{ editId ? 'Actualizar Alumno' : 'Agregar Alumno' }}
+      </button>
+    </form>
+  </div>
+</div>

--- a/src/app/alumnos/alumno-form.component.ts
+++ b/src/app/alumnos/alumno-form.component.ts
@@ -1,0 +1,57 @@
+import { Component } from '@angular/core';
+import { Router, ActivatedRoute } from '@angular/router';
+import { AlumnoService, AlumnoRequestDto } from './alumno.service';
+
+@Component({
+  selector: 'app-alumno-form',
+  templateUrl: './alumno-form.component.html'
+})
+export class AlumnoFormComponent {
+  dto: AlumnoRequestDto = { nombre: '', apellido: '', fotoPerfil: '' };
+  errors: Record<string, string> = {};
+
+  constructor(
+    private alumnoService: AlumnoService,
+    private router: Router,
+    private route: ActivatedRoute
+  ) {
+    const id = this.route.snapshot.paramMap.get('id');
+    if (id) {
+      this.alumnoService.findById(+id).subscribe(alumno => {
+        this.dto = {
+          nombre: alumno.nombre,
+          apellido: alumno.apellido,
+          fotoPerfil: alumno.fotoPerfil
+        };
+        this.editId = +id;
+      });
+    }
+  }
+
+  editId?: number;
+
+  submit() {
+    this.errors = {};
+    const request = this.editId
+      ? this.alumnoService.update(this.editId, this.dto)
+      : this.alumnoService.create(this.dto);
+    request.subscribe({
+      next: () => {
+        this.router.navigate(['/alumnos']);
+      },
+      error: err => {
+        const detail = err.error?.detail;
+        const messages = detail?.messages || err.error?.messages;
+        if (Array.isArray(messages)) {
+          for (const m of messages) {
+            if (m.field) {
+              this.errors[m.field] = m.value;
+            }
+          }
+        } else if (detail?.field) {
+          this.errors[detail.field] = detail.value;
+        }
+      }
+    });
+  }
+}

--- a/src/app/alumnos/alumno-list.component.html
+++ b/src/app/alumnos/alumno-list.component.html
@@ -1,0 +1,62 @@
+<div class="mb-2 text-end">
+  <a class="btn btn-primary" routerLink="/alumnos/new">Agregar Alumno</a>
+</div>
+<div class="card shadow mb-4">
+  <div class="card-header py-3">
+    <h6 class="m-0 font-weight-bold text-primary">Alumnos</h6>
+  </div>
+  <div class="card-body">
+    <div *ngIf="errorMessage" class="alert alert-danger alert-dismissible" role="alert">
+      {{ errorMessage }}
+      <button type="button" class="btn-close" aria-label="Close" (click)="errorMessage = ''"></button>
+    </div>
+    <div class="table-responsive">
+      <table class="table table-bordered table-striped" width="100%" cellspacing="0">
+        <thead>
+          <tr>
+            <th (click)="sort('id')" style="cursor:pointer">ID</th>
+            <th (click)="sort('nombre')" style="cursor:pointer">Nombre</th>
+            <th (click)="sort('apellido')" style="cursor:pointer">Apellido</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let alumno of alumnos">
+            <td>{{ alumno.id }}</td>
+            <td>{{ alumno.nombre }}</td>
+            <td>{{ alumno.apellido }}</td>
+            <td class="text-nowrap">
+              <a class="btn btn-info btn-icon-split btn-sm me-1" [routerLink]="['/alumnos', alumno.id]">
+                <span class="icon text-white-50"><i class="fas fa-edit"></i></span>
+                <span class="text">Editar</span>
+              </a>
+              <button class="btn btn-danger btn-icon-split btn-sm" (click)="confirmDelete(alumno.id)">
+                <span class="icon text-white-50"><i class="fas fa-trash"></i></span>
+                <span class="text">Eliminar</span>
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+<!-- Confirm Delete Modal -->
+<div class="modal fade" id="alumnoDeleteModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Confirmar eliminación</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        ¿Estás seguro que deseas eliminar este registro?
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+        <button type="button" class="btn btn-danger" (click)="deleteConfirmed()">Eliminar</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/alumnos/alumno-list.component.ts
+++ b/src/app/alumnos/alumno-list.component.ts
@@ -1,0 +1,84 @@
+import { Component, OnInit } from '@angular/core';
+import { AlumnoService, AlumnoResponseDto } from './alumno.service';
+
+@Component({
+  selector: 'app-alumno-list',
+  templateUrl: './alumno-list.component.html'
+})
+export class AlumnoListComponent implements OnInit {
+  alumnos: AlumnoResponseDto[] = [];
+  deleteId?: number;
+  modal: any;
+  errorMessage = '';
+  sortKey: 'id' | 'nombre' | 'apellido' = 'id';
+  sortAsc = true;
+
+  constructor(private alumnoService: AlumnoService) {}
+
+  ngOnInit() {
+    this.getAlumnos();
+  }
+
+  getAlumnos() {
+    this.alumnoService.findAll().subscribe(alumnos => {
+      this.alumnos = alumnos;
+      this.applySort();
+    });
+  }
+
+  confirmDelete(id: number) {
+    this.deleteId = id;
+    const el = document.getElementById('alumnoDeleteModal');
+    if (el) {
+      this.modal = new (window as any).bootstrap.Modal(el);
+      this.modal.show();
+    }
+  }
+
+  deleteConfirmed() {
+    if (!this.deleteId) {
+      return;
+    }
+    this.alumnoService.delete(this.deleteId).subscribe({
+      next: () => {
+        this.getAlumnos();
+        if (this.modal) {
+          this.modal.hide();
+        }
+      },
+      error: err => {
+        if (err.status === 409) {
+          if (this.modal) {
+            this.modal.hide();
+          }
+          const backendMsg = typeof err.error === 'string' ? err.error : err.error?.message;
+          this.errorMessage = backendMsg || 'No se puede eliminar el registro';
+        }
+      }
+    });
+  }
+
+  sort(field: 'id' | 'nombre' | 'apellido') {
+    if (this.sortKey === field) {
+      this.sortAsc = !this.sortAsc;
+    } else {
+      this.sortKey = field;
+      this.sortAsc = true;
+    }
+    this.applySort();
+  }
+
+  private applySort() {
+    this.alumnos.sort((a: any, b: any) => {
+      const aValue = a[this.sortKey];
+      const bValue = b[this.sortKey];
+      if (aValue < bValue) {
+        return this.sortAsc ? -1 : 1;
+      }
+      if (aValue > bValue) {
+        return this.sortAsc ? 1 : -1;
+      }
+      return 0;
+    });
+  }
+}

--- a/src/app/alumnos/alumno.service.ts
+++ b/src/app/alumnos/alumno.service.ts
@@ -1,0 +1,49 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
+
+export interface AlumnoResponseDto {
+  id: number;
+  nombre: string;
+  apellido: string;
+  fotoPerfil: string;
+}
+
+export interface AlumnoRequestDto {
+  nombre: string;
+  apellido: string;
+  fotoPerfil: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class AlumnoService {
+  private api = `${environment.apiUrl}/alumnos`;
+
+  constructor(private http: HttpClient) {}
+
+  findAll(): Observable<AlumnoResponseDto[]> {
+    return this.http
+      .get<{ data: AlumnoResponseDto[] }>(this.api)
+      .pipe(map(res => res.data));
+  }
+
+  findById(id: number): Observable<AlumnoResponseDto> {
+    return this.http
+      .get<{ data: AlumnoResponseDto }>(`${this.api}/${id}`)
+      .pipe(map(res => res.data));
+  }
+
+  create(dto: AlumnoRequestDto): Observable<AlumnoResponseDto> {
+    return this.http.post<AlumnoResponseDto>(this.api, dto);
+  }
+
+  update(id: number, dto: AlumnoRequestDto): Observable<AlumnoResponseDto> {
+    return this.http.put<AlumnoResponseDto>(`${this.api}/${id}`, dto);
+  }
+
+  delete(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.api}/${id}`);
+  }
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -29,6 +29,18 @@
           <span>Materias</span>
         </a>
       </li>
+      <li class="nav-item">
+        <a class="nav-link" routerLink="/profesores">
+          <i class="fas fa-chalkboard-teacher"></i>
+          <span>Profesores</span>
+        </a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" routerLink="/alumnos">
+          <i class="fas fa-user-graduate"></i>
+          <span>Alumnos</span>
+        </a>
+      </li>
     </ul>
 
   <!-- Content Wrapper -->

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -13,6 +13,10 @@ import { CarreraListComponent } from './carreras/carrera-list.component';
 import { CarreraFormComponent } from './carreras/carrera-form.component';
 import { MateriaListComponent } from './materias/materia-list.component';
 import { MateriaFormComponent } from './materias/materia-form.component';
+import { AlumnoListComponent } from './alumnos/alumno-list.component';
+import { AlumnoFormComponent } from './alumnos/alumno-form.component';
+import { ProfesorListComponent } from './profesores/profesor-list.component';
+import { ProfesorFormComponent } from './profesores/profesor-form.component';
 
 const routes: Routes = [
   { path: '', redirectTo: 'users', pathMatch: 'full' },
@@ -27,7 +31,13 @@ const routes: Routes = [
   { path: 'carreras/:id', component: CarreraFormComponent },
   { path: 'materias', component: MateriaListComponent },
   { path: 'materias/new', component: MateriaFormComponent },
-  { path: 'materias/:id', component: MateriaFormComponent }
+  { path: 'materias/:id', component: MateriaFormComponent },
+  { path: 'alumnos', component: AlumnoListComponent },
+  { path: 'alumnos/new', component: AlumnoFormComponent },
+  { path: 'alumnos/:id', component: AlumnoFormComponent },
+  { path: 'profesores', component: ProfesorListComponent },
+  { path: 'profesores/new', component: ProfesorFormComponent },
+  { path: 'profesores/:id', component: ProfesorFormComponent }
 ];
 
 @NgModule({
@@ -40,7 +50,11 @@ const routes: Routes = [
     CarreraListComponent,
     CarreraFormComponent,
     MateriaListComponent,
-    MateriaFormComponent
+    MateriaFormComponent,
+    AlumnoListComponent,
+    AlumnoFormComponent,
+    ProfesorListComponent,
+    ProfesorFormComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/profesores/profesor-form.component.html
+++ b/src/app/profesores/profesor-form.component.html
@@ -1,0 +1,38 @@
+<div class="card shadow mb-4">
+  <div class="card-header py-3">
+    <h6 class="m-0 font-weight-bold text-primary">
+      {{ editId ? 'Editar Profesor' : 'Agregar Profesor' }}
+    </h6>
+  </div>
+  <div class="card-body">
+    <form (ngSubmit)="submit()" class="mb-3">
+      <div class="mb-2">
+        <label class="form-label">Nombre</label>
+        <input class="form-control" [(ngModel)]="dto.nombre" name="nombre" placeholder="Nombre del profesor" required
+               [ngClass]="{ 'is-invalid': errors['nombre'] }">
+        <div *ngIf="errors['nombre']" class="invalid-feedback">
+          {{ errors['nombre'] }}
+        </div>
+      </div>
+      <div class="mb-2">
+        <label class="form-label">Apellido</label>
+        <input class="form-control" [(ngModel)]="dto.apellido" name="apellido" placeholder="Apellido del profesor" required
+               [ngClass]="{ 'is-invalid': errors['apellido'] }">
+        <div *ngIf="errors['apellido']" class="invalid-feedback">
+          {{ errors['apellido'] }}
+        </div>
+      </div>
+      <div class="mb-2">
+        <label class="form-label">Foto de Perfil</label>
+        <input class="form-control" [(ngModel)]="dto.fotoPerfil" name="fotoPerfil" placeholder="URL de la foto" required
+               [ngClass]="{ 'is-invalid': errors['fotoPerfil'] }">
+        <div *ngIf="errors['fotoPerfil']" class="invalid-feedback">
+          {{ errors['fotoPerfil'] }}
+        </div>
+      </div>
+      <button type="submit" class="btn btn-primary">
+        {{ editId ? 'Actualizar Profesor' : 'Agregar Profesor' }}
+      </button>
+    </form>
+  </div>
+</div>

--- a/src/app/profesores/profesor-form.component.ts
+++ b/src/app/profesores/profesor-form.component.ts
@@ -1,0 +1,57 @@
+import { Component } from '@angular/core';
+import { Router, ActivatedRoute } from '@angular/router';
+import { ProfesorService, ProfesorRequestDto } from './profesor.service';
+
+@Component({
+  selector: 'app-profesor-form',
+  templateUrl: './profesor-form.component.html'
+})
+export class ProfesorFormComponent {
+  dto: ProfesorRequestDto = { nombre: '', apellido: '', fotoPerfil: '' };
+  errors: Record<string, string> = {};
+
+  constructor(
+    private profesorService: ProfesorService,
+    private router: Router,
+    private route: ActivatedRoute
+  ) {
+    const id = this.route.snapshot.paramMap.get('id');
+    if (id) {
+      this.profesorService.findById(+id).subscribe(profesor => {
+        this.dto = {
+          nombre: profesor.nombre,
+          apellido: profesor.apellido,
+          fotoPerfil: profesor.fotoPerfil
+        };
+        this.editId = +id;
+      });
+    }
+  }
+
+  editId?: number;
+
+  submit() {
+    this.errors = {};
+    const request = this.editId
+      ? this.profesorService.update(this.editId, this.dto)
+      : this.profesorService.create(this.dto);
+    request.subscribe({
+      next: () => {
+        this.router.navigate(['/profesores']);
+      },
+      error: err => {
+        const detail = err.error?.detail;
+        const messages = detail?.messages || err.error?.messages;
+        if (Array.isArray(messages)) {
+          for (const m of messages) {
+            if (m.field) {
+              this.errors[m.field] = m.value;
+            }
+          }
+        } else if (detail?.field) {
+          this.errors[detail.field] = detail.value;
+        }
+      }
+    });
+  }
+}

--- a/src/app/profesores/profesor-list.component.html
+++ b/src/app/profesores/profesor-list.component.html
@@ -1,0 +1,62 @@
+<div class="mb-2 text-end">
+  <a class="btn btn-primary" routerLink="/profesores/new">Agregar Profesor</a>
+</div>
+<div class="card shadow mb-4">
+  <div class="card-header py-3">
+    <h6 class="m-0 font-weight-bold text-primary">Profesores</h6>
+  </div>
+  <div class="card-body">
+    <div *ngIf="errorMessage" class="alert alert-danger alert-dismissible" role="alert">
+      {{ errorMessage }}
+      <button type="button" class="btn-close" aria-label="Close" (click)="errorMessage = ''"></button>
+    </div>
+    <div class="table-responsive">
+      <table class="table table-bordered table-striped" width="100%" cellspacing="0">
+        <thead>
+          <tr>
+            <th (click)="sort('id')" style="cursor:pointer">ID</th>
+            <th (click)="sort('nombre')" style="cursor:pointer">Nombre</th>
+            <th (click)="sort('apellido')" style="cursor:pointer">Apellido</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let profesor of profesores">
+            <td>{{ profesor.id }}</td>
+            <td>{{ profesor.nombre }}</td>
+            <td>{{ profesor.apellido }}</td>
+            <td class="text-nowrap">
+              <a class="btn btn-info btn-icon-split btn-sm me-1" [routerLink]="['/profesores', profesor.id]">
+                <span class="icon text-white-50"><i class="fas fa-edit"></i></span>
+                <span class="text">Editar</span>
+              </a>
+              <button class="btn btn-danger btn-icon-split btn-sm" (click)="confirmDelete(profesor.id)">
+                <span class="icon text-white-50"><i class="fas fa-trash"></i></span>
+                <span class="text">Eliminar</span>
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+<!-- Confirm Delete Modal -->
+<div class="modal fade" id="profesorDeleteModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Confirmar eliminación</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        ¿Estás seguro que deseas eliminar este registro?
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+        <button type="button" class="btn btn-danger" (click)="deleteConfirmed()">Eliminar</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/profesores/profesor-list.component.ts
+++ b/src/app/profesores/profesor-list.component.ts
@@ -1,0 +1,84 @@
+import { Component, OnInit } from '@angular/core';
+import { ProfesorService, ProfesorResponseDto } from './profesor.service';
+
+@Component({
+  selector: 'app-profesor-list',
+  templateUrl: './profesor-list.component.html'
+})
+export class ProfesorListComponent implements OnInit {
+  profesores: ProfesorResponseDto[] = [];
+  deleteId?: number;
+  modal: any;
+  errorMessage = '';
+  sortKey: 'id' | 'nombre' | 'apellido' = 'id';
+  sortAsc = true;
+
+  constructor(private profesorService: ProfesorService) {}
+
+  ngOnInit() {
+    this.getProfesores();
+  }
+
+  getProfesores() {
+    this.profesorService.findAll().subscribe(profesores => {
+      this.profesores = profesores;
+      this.applySort();
+    });
+  }
+
+  confirmDelete(id: number) {
+    this.deleteId = id;
+    const el = document.getElementById('profesorDeleteModal');
+    if (el) {
+      this.modal = new (window as any).bootstrap.Modal(el);
+      this.modal.show();
+    }
+  }
+
+  deleteConfirmed() {
+    if (!this.deleteId) {
+      return;
+    }
+    this.profesorService.delete(this.deleteId).subscribe({
+      next: () => {
+        this.getProfesores();
+        if (this.modal) {
+          this.modal.hide();
+        }
+      },
+      error: err => {
+        if (err.status === 409) {
+          if (this.modal) {
+            this.modal.hide();
+          }
+          const backendMsg = typeof err.error === 'string' ? err.error : err.error?.message;
+          this.errorMessage = backendMsg || 'No se puede eliminar el registro';
+        }
+      }
+    });
+  }
+
+  sort(field: 'id' | 'nombre' | 'apellido') {
+    if (this.sortKey === field) {
+      this.sortAsc = !this.sortAsc;
+    } else {
+      this.sortKey = field;
+      this.sortAsc = true;
+    }
+    this.applySort();
+  }
+
+  private applySort() {
+    this.profesores.sort((a: any, b: any) => {
+      const aValue = a[this.sortKey];
+      const bValue = b[this.sortKey];
+      if (aValue < bValue) {
+        return this.sortAsc ? -1 : 1;
+      }
+      if (aValue > bValue) {
+        return this.sortAsc ? 1 : -1;
+      }
+      return 0;
+    });
+  }
+}

--- a/src/app/profesores/profesor.service.ts
+++ b/src/app/profesores/profesor.service.ts
@@ -1,0 +1,49 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
+
+export interface ProfesorResponseDto {
+  id: number;
+  nombre: string;
+  apellido: string;
+  fotoPerfil: string;
+}
+
+export interface ProfesorRequestDto {
+  nombre: string;
+  apellido: string;
+  fotoPerfil: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ProfesorService {
+  private api = `${environment.apiUrl}/profesores`;
+
+  constructor(private http: HttpClient) {}
+
+  findAll(): Observable<ProfesorResponseDto[]> {
+    return this.http
+      .get<{ data: ProfesorResponseDto[] }>(this.api)
+      .pipe(map(res => res.data));
+  }
+
+  findById(id: number): Observable<ProfesorResponseDto> {
+    return this.http
+      .get<{ data: ProfesorResponseDto }>(`${this.api}/${id}`)
+      .pipe(map(res => res.data));
+  }
+
+  create(dto: ProfesorRequestDto): Observable<ProfesorResponseDto> {
+    return this.http.post<ProfesorResponseDto>(this.api, dto);
+  }
+
+  update(id: number, dto: ProfesorRequestDto): Observable<ProfesorResponseDto> {
+    return this.http.put<ProfesorResponseDto>(`${this.api}/${id}`, dto);
+  }
+
+  delete(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.api}/${id}`);
+  }
+}


### PR DESCRIPTION
## Summary
- implement alumno service, list/form components and html
- implement profesor service, list/form components and html
- register new components and routes
- extend sidebar menu with Profesor and Alumno links

## Testing
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a0ac70378832f8a79fc8108468589