### PR TITLE
Add Año Académico CRUD

### DIFF
--- a/src/app/anios-academicos/anio-academico-form.component.html
+++ b/src/app/anios-academicos/anio-academico-form.component.html
@@ -1,0 +1,27 @@
+<div class="card shadow mb-4">
+  <div class="card-header py-3">
+    <h6 class="m-0 font-weight-bold text-primary">
+      {{ editId ? 'Editar Año Académico' : 'Agregar Año Académico' }}
+    </h6>
+  </div>
+  <div class="card-body">
+    <form (ngSubmit)="submit()" class="mb-3">
+      <div class="mb-2">
+        <label class="form-label">Año</label>
+        <input type="number" class="form-control" [(ngModel)]="dto.anio" name="anio" required
+               [ngClass]="{ 'is-invalid': errors['anio'] }">
+        <div *ngIf="errors['anio']" class="invalid-feedback">
+          {{ errors['anio'] }}
+        </div>
+      </div>
+      <div class="form-check mb-2">
+        <input type="checkbox" class="form-check-input" [(ngModel)]="dto.activo" name="activo" id="activo">
+        <label class="form-check-label" for="activo">Activo</label>
+      </div>
+      <button type="submit" class="btn btn-primary">
+        {{ editId ? 'Actualizar Año Académico' : 'Agregar Año Académico' }}
+      </button>
+    </form>
+  </div>
+</div>
+

--- a/src/app/anios-academicos/anio-academico-form.component.ts
+++ b/src/app/anios-academicos/anio-academico-form.component.ts
@@ -1,0 +1,54 @@
+import { Component } from '@angular/core';
+import { Router, ActivatedRoute } from '@angular/router';
+import { AnioAcademicoService, AnioAcademicoRequestDto } from './anio-academico.service';
+
+@Component({
+  selector: 'app-anio-academico-form',
+  templateUrl: './anio-academico-form.component.html'
+})
+export class AnioAcademicoFormComponent {
+  dto: AnioAcademicoRequestDto = { anio: new Date().getFullYear(), activo: false };
+  errors: Record<string, string> = {};
+
+  constructor(
+    private anioService: AnioAcademicoService,
+    private router: Router,
+    private route: ActivatedRoute
+  ) {
+    const id = this.route.snapshot.paramMap.get('id');
+    if (id) {
+      this.anioService.findById(+id).subscribe(anio => {
+        this.dto = { anio: anio.anio, activo: anio.activo };
+        this.editId = +id;
+      });
+    }
+  }
+
+  editId?: number;
+
+  submit() {
+    this.errors = {};
+    const request = this.editId
+      ? this.anioService.update(this.editId, this.dto)
+      : this.anioService.create(this.dto);
+    request.subscribe({
+      next: () => {
+        this.router.navigate(['/anios-academicos']);
+      },
+      error: err => {
+        const detail = err.error?.detail;
+        const messages = detail?.messages || err.error?.messages;
+        if (Array.isArray(messages)) {
+          for (const m of messages) {
+            if (m.field) {
+              this.errors[m.field] = m.value;
+            }
+          }
+        } else if (detail?.field) {
+          this.errors[detail.field] = detail.value;
+        }
+      }
+    });
+  }
+}
+

--- a/src/app/anios-academicos/anio-academico-list.component.html
+++ b/src/app/anios-academicos/anio-academico-list.component.html
@@ -1,0 +1,62 @@
+<div class="mb-2 text-end">
+  <a class="btn btn-primary" routerLink="/anios-academicos/new">Agregar Año Académico</a>
+</div>
+<div class="card shadow mb-4">
+  <div class="card-header py-3">
+    <h6 class="m-0 font-weight-bold text-primary">Años Académicos</h6>
+  </div>
+  <div class="card-body">
+    <div *ngIf="errorMessage" class="alert alert-danger alert-dismissible" role="alert">
+      {{ errorMessage }}
+      <button type="button" class="btn-close" aria-label="Close" (click)="errorMessage = ''"></button>
+    </div>
+    <div class="table-responsive">
+      <table class="table table-bordered table-striped" width="100%" cellspacing="0">
+        <thead>
+          <tr>
+            <th (click)="sort('id')" style="cursor:pointer">ID</th>
+            <th (click)="sort('anio')" style="cursor:pointer">Año</th>
+            <th (click)="sort('activo')" style="cursor:pointer">Activo</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let anio of anios">
+            <td>{{ anio.id }}</td>
+            <td>{{ anio.anio }}</td>
+            <td>{{ anio.activo ? 'Sí' : 'No' }}</td>
+            <td class="text-nowrap">
+              <a class="btn btn-info btn-icon-split btn-sm me-1" [routerLink]="['/anios-academicos', anio.id]">
+                <span class="icon text-white-50"><i class="fas fa-edit"></i></span>
+                <span class="text">Editar</span>
+              </a>
+              <button class="btn btn-danger btn-icon-split btn-sm" (click)="confirmDelete(anio.id)">
+                <span class="icon text-white-50"><i class="fas fa-trash"></i></span>
+                <span class="text">Eliminar</span>
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+<!-- Confirm Delete Modal -->
+<div class="modal fade" id="anioAcademicoDeleteModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Confirmar eliminación</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        ¿Estás seguro que deseas eliminar este registro?
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+        <button type="button" class="btn btn-danger" (click)="deleteConfirmed()">Eliminar</button>
+      </div>
+    </div>
+  </div>
+</div>
+

--- a/src/app/anios-academicos/anio-academico-list.component.ts
+++ b/src/app/anios-academicos/anio-academico-list.component.ts
@@ -1,0 +1,85 @@
+import { Component, OnInit } from '@angular/core';
+import { AnioAcademicoService, AnioAcademicoResponseDto } from './anio-academico.service';
+
+@Component({
+  selector: 'app-anio-academico-list',
+  templateUrl: './anio-academico-list.component.html'
+})
+export class AnioAcademicoListComponent implements OnInit {
+  anios: AnioAcademicoResponseDto[] = [];
+  deleteId?: number;
+  modal: any;
+  errorMessage = '';
+  sortKey: 'id' | 'anio' | 'activo' = 'id';
+  sortAsc = true;
+
+  constructor(private anioService: AnioAcademicoService) {}
+
+  ngOnInit() {
+    this.getAnios();
+  }
+
+  getAnios() {
+    this.anioService.findAll().subscribe(anios => {
+      this.anios = anios;
+      this.applySort();
+    });
+  }
+
+  confirmDelete(id: number) {
+    this.deleteId = id;
+    const el = document.getElementById('anioAcademicoDeleteModal');
+    if (el) {
+      this.modal = new (window as any).bootstrap.Modal(el);
+      this.modal.show();
+    }
+  }
+
+  deleteConfirmed() {
+    if (!this.deleteId) {
+      return;
+    }
+    this.anioService.delete(this.deleteId).subscribe({
+      next: () => {
+        this.getAnios();
+        if (this.modal) {
+          this.modal.hide();
+        }
+      },
+      error: err => {
+        if (err.status === 409) {
+          if (this.modal) {
+            this.modal.hide();
+          }
+          const backendMsg = typeof err.error === 'string' ? err.error : err.error?.message;
+          this.errorMessage = backendMsg || 'No se puede eliminar el registro';
+        }
+      }
+    });
+  }
+
+  sort(field: 'id' | 'anio' | 'activo') {
+    if (this.sortKey === field) {
+      this.sortAsc = !this.sortAsc;
+    } else {
+      this.sortKey = field;
+      this.sortAsc = true;
+    }
+    this.applySort();
+  }
+
+  private applySort() {
+    this.anios.sort((a: any, b: any) => {
+      const aValue = a[this.sortKey];
+      const bValue = b[this.sortKey];
+      if (aValue < bValue) {
+        return this.sortAsc ? -1 : 1;
+      }
+      if (aValue > bValue) {
+        return this.sortAsc ? 1 : -1;
+      }
+      return 0;
+    });
+  }
+}
+

--- a/src/app/anios-academicos/anio-academico.service.ts
+++ b/src/app/anios-academicos/anio-academico.service.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
+
+export interface AnioAcademicoResponseDto {
+  id: number;
+  anio: number;
+  activo: boolean;
+}
+
+export interface AnioAcademicoRequestDto {
+  anio: number;
+  activo: boolean;
+}
+
+@Injectable({ providedIn: 'root' })
+export class AnioAcademicoService {
+  private api = `${environment.apiUrl}/anios-academicos`;
+
+  constructor(private http: HttpClient) {}
+
+  findAll(): Observable<AnioAcademicoResponseDto[]> {
+    return this.http
+      .get<{ data: AnioAcademicoResponseDto[] }>(this.api)
+      .pipe(map(res => res.data));
+  }
+
+  create(dto: AnioAcademicoRequestDto): Observable<AnioAcademicoResponseDto> {
+    return this.http.post<AnioAcademicoResponseDto>(this.api, dto);
+  }
+
+  findById(id: number): Observable<AnioAcademicoResponseDto> {
+    return this.http
+      .get<{ data: AnioAcademicoResponseDto }>(`${this.api}/${id}`)
+      .pipe(map(res => res.data));
+  }
+
+  update(id: number, dto: AnioAcademicoRequestDto): Observable<AnioAcademicoResponseDto> {
+    return this.http.put<AnioAcademicoResponseDto>(`${this.api}/${id}`, dto);
+  }
+
+  delete(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.api}/${id}`);
+  }
+}
+

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -30,6 +30,17 @@
         </a>
       </li>
       <li class="nav-item">
+        <a class="nav-link collapsed" href="#" data-bs-toggle="collapse" data-bs-target="#collapseCursos" aria-expanded="false" aria-controls="collapseCursos">
+          <i class="fas fa-school"></i>
+          <span>Cursos</span>
+        </a>
+        <div id="collapseCursos" class="collapse" data-bs-parent="#accordionSidebar">
+          <div class="bg-white py-2 collapse-inner rounded">
+            <a class="collapse-item" routerLink="/anios-academicos">Años Académicos</a>
+          </div>
+        </div>
+      </li>
+      <li class="nav-item">
         <a class="nav-link" routerLink="/profesores">
           <i class="fas fa-chalkboard-teacher"></i>
           <span>Profesores</span>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -17,6 +17,8 @@ import { AlumnoListComponent } from './alumnos/alumno-list.component';
 import { AlumnoFormComponent } from './alumnos/alumno-form.component';
 import { ProfesorListComponent } from './profesores/profesor-list.component';
 import { ProfesorFormComponent } from './profesores/profesor-form.component';
+import { AnioAcademicoListComponent } from './anios-academicos/anio-academico-list.component';
+import { AnioAcademicoFormComponent } from './anios-academicos/anio-academico-form.component';
 
 const routes: Routes = [
   { path: '', redirectTo: 'users', pathMatch: 'full' },
@@ -37,7 +39,10 @@ const routes: Routes = [
   { path: 'alumnos/:id', component: AlumnoFormComponent },
   { path: 'profesores', component: ProfesorListComponent },
   { path: 'profesores/new', component: ProfesorFormComponent },
-  { path: 'profesores/:id', component: ProfesorFormComponent }
+  { path: 'profesores/:id', component: ProfesorFormComponent },
+  { path: 'anios-academicos', component: AnioAcademicoListComponent },
+  { path: 'anios-academicos/new', component: AnioAcademicoFormComponent },
+  { path: 'anios-academicos/:id', component: AnioAcademicoFormComponent }
 ];
 
 @NgModule({
@@ -54,7 +59,9 @@ const routes: Routes = [
     AlumnoListComponent,
     AlumnoFormComponent,
     ProfesorListComponent,
-    ProfesorFormComponent
+    ProfesorFormComponent,
+    AnioAcademicoListComponent,
+    AnioAcademicoFormComponent
   ],
   imports: [
     BrowserModule,


### PR DESCRIPTION
## Summary
- add Año Académico service
- add list and form components for Año Académico
- wire routes and declarations
- add `Cursos` menu with sub-item for Año Académico

## Testing
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a13e8eaec832fa5b09a8106970740