### PR TITLE
Reorganizar menu lateral

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -28,6 +28,7 @@
           <a class="collapse-item" routerLink="/materias">Materias</a>
           <a class="collapse-item" routerLink="/cursos">Cursos</a>
           <a class="collapse-item" routerLink="/profesores">Profesores</a>
+          <a class="collapse-item" routerLink="/alumnos">Alumnos</a>
         </div>
       </div>
     </li>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -8,7 +8,7 @@
     <li class="nav-item">
       <a class="nav-link collapsed" href="#" data-bs-toggle="collapse" data-bs-target="#collapseAdmin" aria-expanded="false" aria-controls="collapseAdmin">
         <i class="fas fa-user-shield"></i>
-        <span></span>
+        <span>Administración</span>
       </a>
       <div id="collapseAdmin" class="collapse" data-bs-parent="#accordionSidebar">
         <div class="bg-white py-2 collapse-inner rounded">
@@ -20,7 +20,7 @@
     <li class="nav-item">
       <a class="nav-link collapsed" href="#" data-bs-toggle="collapse" data-bs-target="#collapseAcademico" aria-expanded="false" aria-controls="collapseAcademico">
         <i class="fas fa-university"></i>
-        <span></span>
+        <span>Académico</span>
       </a>
       <div id="collapseAcademico" class="collapse" data-bs-parent="#accordionSidebar">
         <div class="bg-white py-2 collapse-inner rounded">

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -6,53 +6,33 @@
     </a>
     <hr class="sidebar-divider my-0">
     <li class="nav-item">
-      <a class="nav-link" routerLink="/users">
-        <i class="fas fa-users"></i>
-        <span>Usuarios</span>
+      <a class="nav-link collapsed" href="#" data-bs-toggle="collapse" data-bs-target="#collapseAdmin" aria-expanded="false" aria-controls="collapseAdmin">
+        <i class="fas fa-user-shield"></i>
+        <span>Administración</span>
       </a>
-    </li>
-      <li class="nav-item">
-        <a class="nav-link" routerLink="/groups">
-          <i class="fas fa-layer-group"></i>
-          <span>Grupos</span>
-        </a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" routerLink="/carreras">
-          <i class="fas fa-graduation-cap"></i>
-          <span>Carreras</span>
-        </a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" routerLink="/materias">
-          <i class="fas fa-book"></i>
-          <span>Materias</span>
-        </a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link collapsed" href="#" data-bs-toggle="collapse" data-bs-target="#collapseCursos" aria-expanded="false" aria-controls="collapseCursos">
-          <i class="fas fa-school"></i>
-          <span>Cursos</span>
-        </a>
-        <div id="collapseCursos" class="collapse" data-bs-parent="#accordionSidebar">
-          <div class="bg-white py-2 collapse-inner rounded">
-            <a class="collapse-item" routerLink="/cursos">Cursos</a>
-            <a class="collapse-item" routerLink="/anios-academicos">Años Académicos</a>
-          </div>
+      <div id="collapseAdmin" class="collapse" data-bs-parent="#accordionSidebar">
+        <div class="bg-white py-2 collapse-inner rounded">
+          <a class="collapse-item" routerLink="/users">Usuarios</a>
+          <a class="collapse-item" routerLink="/groups">Grupos</a>
         </div>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" routerLink="/profesores">
-          <i class="fas fa-chalkboard-teacher"></i>
-          <span>Profesores</span>
-        </a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" routerLink="/alumnos">
-          <i class="fas fa-user-graduate"></i>
-          <span>Alumnos</span>
-        </a>
-      </li>
+      </div>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link collapsed" href="#" data-bs-toggle="collapse" data-bs-target="#collapseAcademico" aria-expanded="false" aria-controls="collapseAcademico">
+        <i class="fas fa-university"></i>
+        <span>Académico</span>
+      </a>
+      <div id="collapseAcademico" class="collapse" data-bs-parent="#accordionSidebar">
+        <div class="bg-white py-2 collapse-inner rounded">
+          <a class="collapse-item" routerLink="/carreras">Carreras</a>
+          <a class="collapse-item" routerLink="/materias">Materias</a>
+          <a class="collapse-item" routerLink="/cursos">Cursos</a>
+          <a class="collapse-item" routerLink="/anios-academicos">Años Académicos</a>
+          <a class="collapse-item" routerLink="/profesores">Profesores</a>
+          <a class="collapse-item" routerLink="/alumnos">Alumnos</a>
+        </div>
+      </div>
+    </li>
     </ul>
 
   <!-- Content Wrapper -->

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -8,7 +8,7 @@
     <li class="nav-item">
       <a class="nav-link collapsed" href="#" data-bs-toggle="collapse" data-bs-target="#collapseAdmin" aria-expanded="false" aria-controls="collapseAdmin">
         <i class="fas fa-user-shield"></i>
-        <span>Administración</span>
+        <span></span>
       </a>
       <div id="collapseAdmin" class="collapse" data-bs-parent="#accordionSidebar">
         <div class="bg-white py-2 collapse-inner rounded">
@@ -20,7 +20,7 @@
     <li class="nav-item">
       <a class="nav-link collapsed" href="#" data-bs-toggle="collapse" data-bs-target="#collapseAcademico" aria-expanded="false" aria-controls="collapseAcademico">
         <i class="fas fa-university"></i>
-        <span>Académico</span>
+        <span></span>
       </a>
       <div id="collapseAcademico" class="collapse" data-bs-parent="#accordionSidebar">
         <div class="bg-white py-2 collapse-inner rounded">

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -28,7 +28,6 @@
           <a class="collapse-item" routerLink="/materias">Materias</a>
           <a class="collapse-item" routerLink="/cursos">Cursos</a>
           <a class="collapse-item" routerLink="/profesores">Profesores</a>
-          <a class="collapse-item" routerLink="/users">Usuarios</a>
         </div>
       </div>
     </li>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -6,11 +6,11 @@
     </a>
     <hr class="sidebar-divider my-0">
     <li class="nav-item">
-      <a class="nav-link collapsed" href="#" data-bs-toggle="collapse" data-bs-target="#collapseAdmin" aria-expanded="false" aria-controls="collapseAdmin">
+      <a class="nav-link collapsed" href="#" data-bs-toggle="collapse" data-bs-target="#collapseGestionUsuarios" aria-expanded="false" aria-controls="collapseGestionUsuarios">
         <i class="fas fa-user-shield"></i>
-        <span>Administración</span>
+        <span>Gestión de Usuarios</span>
       </a>
-      <div id="collapseAdmin" class="collapse" data-bs-parent="#accordionSidebar">
+      <div id="collapseGestionUsuarios" class="collapse" data-bs-parent="#accordionSidebar">
         <div class="bg-white py-2 collapse-inner rounded">
           <a class="collapse-item" routerLink="/users">Usuarios</a>
           <a class="collapse-item" routerLink="/groups">Grupos</a>
@@ -18,18 +18,17 @@
       </div>
     </li>
     <li class="nav-item">
-      <a class="nav-link collapsed" href="#" data-bs-toggle="collapse" data-bs-target="#collapseAcademico" aria-expanded="false" aria-controls="collapseAcademico">
+      <a class="nav-link collapsed" href="#" data-bs-toggle="collapse" data-bs-target="#collapseGestionAcademica" aria-expanded="false" aria-controls="collapseGestionAcademica">
         <i class="fas fa-university"></i>
-        <span>Académico</span>
+        <span>Gestión Académica</span>
       </a>
-      <div id="collapseAcademico" class="collapse" data-bs-parent="#accordionSidebar">
+      <div id="collapseGestionAcademica" class="collapse" data-bs-parent="#accordionSidebar">
         <div class="bg-white py-2 collapse-inner rounded">
           <a class="collapse-item" routerLink="/carreras">Carreras</a>
           <a class="collapse-item" routerLink="/materias">Materias</a>
           <a class="collapse-item" routerLink="/cursos">Cursos</a>
-          <a class="collapse-item" routerLink="/anios-academicos">Años Académicos</a>
           <a class="collapse-item" routerLink="/profesores">Profesores</a>
-          <a class="collapse-item" routerLink="/alumnos">Alumnos</a>
+          <a class="collapse-item" routerLink="/users">Usuarios</a>
         </div>
       </div>
     </li>

--- a/src/app/curso-materias/curso-materia.service.ts
+++ b/src/app/curso-materias/curso-materia.service.ts
@@ -4,20 +4,59 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { environment } from '../../environments/environment';
 import { MateriaResponseDto } from '../materias/materia.service';
+import { ProfesorResponseDto } from '../profesores/profesor.service';
+import { CursoResponseDto } from '../cursos/curso.service';
+
+export interface AulaResponseDto {
+  id: number;
+  nombre: string;
+  ubicacion: string;
+  capacidad: number;
+}
+
+export interface ModalidadResponseDto {
+  id: number;
+  nombre: string;
+}
+
+export interface LocalTime {
+  hour: number;
+  minute: number;
+  second: number;
+  nano: number;
+}
+
+export interface ModuloHoraResponseDto {
+  id: number;
+  nombre: string;
+  horaInicio: LocalTime;
+  horaFin: LocalTime;
+}
 
 export interface CursoMateriaResponseDto {
   id: number;
+  curso: CursoResponseDto;
   materia: MateriaResponseDto;
+  profesor: ProfesorResponseDto;
+  aula: AulaResponseDto;
+  diasSemana: string[];
+  moduloHora: ModuloHoraResponseDto;
+  modalidad: ModalidadResponseDto;
 }
 
 export interface CursoMateriaRequestDto {
   cursoId: number;
   materiaId: number;
+  profesorId?: number;
+  aulaId?: number;
+  diasSemana?: string[];
+  moduloHoraId?: number;
+  modalidadId?: number;
 }
 
 @Injectable({ providedIn: 'root' })
 export class CursoMateriaService {
-  private api = `${environment.apiUrl}/curso-materias`;
+  private api = `${environment.apiUrl}/cursos-materia`;
 
   constructor(private http: HttpClient) {}
 
@@ -30,6 +69,12 @@ export class CursoMateriaService {
   create(dto: CursoMateriaRequestDto): Observable<CursoMateriaResponseDto> {
     return this.http
       .post<{ data: CursoMateriaResponseDto }>(this.api, dto)
+      .pipe(map(res => res.data));
+  }
+
+  update(id: number, dto: CursoMateriaRequestDto): Observable<CursoMateriaResponseDto> {
+    return this.http
+      .put<{ data: CursoMateriaResponseDto }>(`${this.api}/${id}`, dto)
       .pipe(map(res => res.data));
   }
 

--- a/src/app/curso-materias/curso-materia.service.ts
+++ b/src/app/curso-materias/curso-materia.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
+import { MateriaResponseDto } from '../materias/materia.service';
+
+export interface CursoMateriaResponseDto {
+  id: number;
+  materia: MateriaResponseDto;
+}
+
+export interface CursoMateriaRequestDto {
+  cursoId: number;
+  materiaId: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class CursoMateriaService {
+  private api = `${environment.apiUrl}/curso-materias`;
+
+  constructor(private http: HttpClient) {}
+
+  findByCurso(cursoId: number): Observable<CursoMateriaResponseDto[]> {
+    return this.http
+      .get<{ data: CursoMateriaResponseDto[] }>(`${this.api}?cursoId=${cursoId}`)
+      .pipe(map(res => res.data));
+  }
+
+  create(dto: CursoMateriaRequestDto): Observable<CursoMateriaResponseDto> {
+    return this.http
+      .post<{ data: CursoMateriaResponseDto }>(this.api, dto)
+      .pipe(map(res => res.data));
+  }
+
+  delete(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.api}/${id}`);
+  }
+}

--- a/src/app/cursos/curso-form.component.html
+++ b/src/app/cursos/curso-form.component.html
@@ -39,5 +39,38 @@
         {{ editId ? 'Actualizar Curso' : 'Agregar Curso' }}
       </button>
     </form>
+    <div *ngIf="editId" class="mt-4">
+      <h6 class="mb-3">Materias del Curso</h6>
+      <form (ngSubmit)="addCursoMateria()" class="row align-items-end mb-3">
+        <div class="col-md-8 mb-2">
+          <label class="form-label">Materia</label>
+          <select class="form-select" [(ngModel)]="materiaId" name="materiaId">
+            <option value="0" disabled selected>Seleccione una materia</option>
+            <option *ngFor="let m of materias" [ngValue]="m.id">{{ m.nombre }}</option>
+          </select>
+        </div>
+        <div class="col-md-4 mb-2">
+          <button type="submit" class="btn btn-secondary w-100">Agregar</button>
+        </div>
+      </form>
+      <table class="table table-bordered">
+        <thead>
+          <tr>
+            <th>Materia</th>
+            <th style="width: 10%">Acciones</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let cm of cursoMaterias">
+            <td>{{ cm.materia.nombre }}</td>
+            <td>
+              <button type="button" class="btn btn-danger btn-sm" (click)="removeCursoMateria(cm.id)">
+                Eliminar
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>

--- a/src/app/cursos/curso-form.component.html
+++ b/src/app/cursos/curso-form.component.html
@@ -6,31 +6,33 @@
   </div>
   <div class="card-body">
     <form (ngSubmit)="submit()" class="mb-3">
-      <div class="mb-2">
-        <label class="form-label">Año Cursado</label>
-        <input type="number" class="form-control" [(ngModel)]="dto.anioCursado" name="anioCursado" required
-               [ngClass]="{ 'is-invalid': errors['anioCursado'] }">
-        <div *ngIf="errors['anioCursado']" class="invalid-feedback">
-          {{ errors['anioCursado'] }}
+      <div class="row">
+        <div class="col-md-4 mb-2">
+          <label class="form-label">Año Cursado</label>
+          <input type="number" class="form-control" [(ngModel)]="dto.anioCursado" name="anioCursado" required
+                 [ngClass]="{ 'is-invalid': errors['anioCursado'] }">
+          <div *ngIf="errors['anioCursado']" class="invalid-feedback">
+            {{ errors['anioCursado'] }}
+          </div>
         </div>
-      </div>
-      <div class="mb-2">
-        <label class="form-label">División</label>
-        <input class="form-control" [(ngModel)]="dto.division" name="division" required
-               [ngClass]="{ 'is-invalid': errors['division'] }">
-        <div *ngIf="errors['division']" class="invalid-feedback">
-          {{ errors['division'] }}
+        <div class="col-md-4 mb-2">
+          <label class="form-label">División</label>
+          <input class="form-control" [(ngModel)]="dto.division" name="division" required
+                 [ngClass]="{ 'is-invalid': errors['division'] }">
+          <div *ngIf="errors['division']" class="invalid-feedback">
+            {{ errors['division'] }}
+          </div>
         </div>
-      </div>
-      <div class="mb-2">
-        <label class="form-label">Año Académico</label>
-        <select class="form-select" [(ngModel)]="dto.anioAcademicoId" name="anioAcademicoId" required
-                [ngClass]="{ 'is-invalid': errors['anioAcademicoId'] }">
-          <option value="" disabled selected>Seleccione un año académico</option>
-          <option *ngFor="let a of anios" [ngValue]="a.id">{{ a.anio }}</option>
-        </select>
-        <div *ngIf="errors['anioAcademicoId']" class="invalid-feedback">
-          {{ errors['anioAcademicoId'] }}
+        <div class="col-md-4 mb-2">
+          <label class="form-label">Año Académico</label>
+          <select class="form-select" [(ngModel)]="dto.anioAcademicoId" name="anioAcademicoId" required
+                  [ngClass]="{ 'is-invalid': errors['anioAcademicoId'] }">
+            <option value="" disabled selected>Seleccione un año académico</option>
+            <option *ngFor="let a of anios" [ngValue]="a.id">{{ a.anio }}</option>
+          </select>
+          <div *ngIf="errors['anioAcademicoId']" class="invalid-feedback">
+            {{ errors['anioAcademicoId'] }}
+          </div>
         </div>
       </div>
       <button type="submit" class="btn btn-primary">

--- a/src/app/cursos/curso-form.component.html
+++ b/src/app/cursos/curso-form.component.html
@@ -53,24 +53,43 @@
           <button type="submit" class="btn btn-secondary w-100">Agregar</button>
         </div>
       </form>
-      <table class="table table-bordered">
-        <thead>
-          <tr>
-            <th>Materia</th>
-            <th style="width: 10%">Acciones</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr *ngFor="let cm of cursoMaterias">
-            <td>{{ cm.materia.nombre }}</td>
-            <td>
-              <button type="button" class="btn btn-danger btn-sm" (click)="removeCursoMateria(cm.id)">
-                Eliminar
-              </button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <div class="table-responsive">
+        <table class="table table-bordered table-striped" width="100%" cellspacing="0">
+          <thead>
+            <tr>
+              <th>Materia</th>
+              <th style="width: 10%">Acciones</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let cm of cursoMaterias">
+              <td>{{ cm.materia.nombre }}</td>
+              <td class="text-nowrap">
+                <button class="btn btn-danger btn-icon-split btn-sm" (click)="confirmDeleteCursoMateria(cm.id)">
+                  <span class="icon text-white-50"><i class="fas fa-trash"></i></span>
+                  <span class="text">Eliminar</span>
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <!-- Confirm Delete Modal -->
+      <div class="modal fade" id="cursoMateriaDeleteModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title">Confirmar eliminación</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">¿Estás seguro que deseas eliminar este registro?</div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+              <button type="button" class="btn btn-danger" (click)="deleteCursoMateriaConfirmed()">Eliminar</button>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/src/app/cursos/curso-form.component.ts
+++ b/src/app/cursos/curso-form.component.ts
@@ -1,7 +1,19 @@
 import { Component } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 import { CursoService, CursoRequestDto } from './curso.service';
-import { AnioAcademicoService, AnioAcademicoResponseDto } from '../anios-academicos/anio-academico.service';
+import {
+  AnioAcademicoService,
+  AnioAcademicoResponseDto
+} from '../anios-academicos/anio-academico.service';
+import {
+  MateriaService,
+  MateriaResponseDto
+} from '../materias/materia.service';
+import {
+  CursoMateriaService,
+  CursoMateriaResponseDto,
+  CursoMateriaRequestDto
+} from '../curso-materias/curso-materia.service';
 
 @Component({
   selector: 'app-curso-form',
@@ -10,15 +22,21 @@ import { AnioAcademicoService, AnioAcademicoResponseDto } from '../anios-academi
 export class CursoFormComponent {
   dto: CursoRequestDto = { anioCursado: undefined, division: '', anioAcademicoId: 0 };
   anios: AnioAcademicoResponseDto[] = [];
+  materias: MateriaResponseDto[] = [];
+  cursoMaterias: CursoMateriaResponseDto[] = [];
+  materiaId = 0;
   errors: Record<string, string> = {};
 
   constructor(
     private cursoService: CursoService,
     private anioService: AnioAcademicoService,
+    private materiaService: MateriaService,
+    private cursoMateriaService: CursoMateriaService,
     private router: Router,
     private route: ActivatedRoute
   ) {
     this.anioService.findAll().subscribe(a => (this.anios = a));
+    this.materiaService.findAll().subscribe(m => (this.materias = m));
     const id = this.route.snapshot.paramMap.get('id');
     if (id) {
       this.cursoService.findById(+id).subscribe(curso => {
@@ -28,6 +46,7 @@ export class CursoFormComponent {
           anioAcademicoId: curso.anioAcademico.id
         };
         this.editId = +id;
+        this.loadCursoMaterias();
       });
     }
   }
@@ -56,6 +75,35 @@ export class CursoFormComponent {
           this.errors[detail.field] = detail.value;
         }
       }
+    });
+  }
+
+  private loadCursoMaterias() {
+    if (!this.editId) {
+      return;
+    }
+    this.cursoMateriaService
+      .findByCurso(this.editId)
+      .subscribe(cm => (this.cursoMaterias = cm));
+  }
+
+  addCursoMateria() {
+    if (!this.editId || !this.materiaId) {
+      return;
+    }
+    const dto: CursoMateriaRequestDto = {
+      cursoId: this.editId,
+      materiaId: this.materiaId
+    };
+    this.cursoMateriaService.create(dto).subscribe(cm => {
+      this.cursoMaterias.push(cm);
+      this.materiaId = 0;
+    });
+  }
+
+  removeCursoMateria(id: number) {
+    this.cursoMateriaService.delete(id).subscribe(() => {
+      this.cursoMaterias = this.cursoMaterias.filter(cm => cm.id !== id);
     });
   }
 }

--- a/src/app/cursos/curso-form.component.ts
+++ b/src/app/cursos/curso-form.component.ts
@@ -25,6 +25,8 @@ export class CursoFormComponent {
   materias: MateriaResponseDto[] = [];
   cursoMaterias: CursoMateriaResponseDto[] = [];
   materiaId = 0;
+  deleteCursoMateriaId?: number;
+  cursoMateriaModal: any;
   errors: Record<string, string> = {};
 
   constructor(
@@ -101,9 +103,26 @@ export class CursoFormComponent {
     });
   }
 
-  removeCursoMateria(id: number) {
-    this.cursoMateriaService.delete(id).subscribe(() => {
-      this.cursoMaterias = this.cursoMaterias.filter(cm => cm.id !== id);
+  confirmDeleteCursoMateria(id: number) {
+    this.deleteCursoMateriaId = id;
+    const el = document.getElementById('cursoMateriaDeleteModal');
+    if (el) {
+      this.cursoMateriaModal = new (window as any).bootstrap.Modal(el);
+      this.cursoMateriaModal.show();
+    }
+  }
+
+  deleteCursoMateriaConfirmed() {
+    if (!this.deleteCursoMateriaId) {
+      return;
+    }
+    this.cursoMateriaService.delete(this.deleteCursoMateriaId).subscribe(() => {
+      this.cursoMaterias = this.cursoMaterias.filter(
+        cm => cm.id !== this.deleteCursoMateriaId
+      );
+      if (this.cursoMateriaModal) {
+        this.cursoMateriaModal.hide();
+      }
     });
   }
 }

--- a/src/app/cursos/curso-form.component.ts
+++ b/src/app/cursos/curso-form.component.ts
@@ -8,7 +8,7 @@ import { AnioAcademicoService, AnioAcademicoResponseDto } from '../anios-academi
   templateUrl: './curso-form.component.html'
 })
 export class CursoFormComponent {
-  dto: CursoRequestDto = { anioCursado: new Date().getFullYear(), division: '', anioAcademicoId: 0 };
+  dto: CursoRequestDto = { anioCursado: undefined, division: '', anioAcademicoId: 0 };
   anios: AnioAcademicoResponseDto[] = [];
   errors: Record<string, string> = {};
 

--- a/src/app/cursos/curso.service.ts
+++ b/src/app/cursos/curso.service.ts
@@ -13,7 +13,7 @@ export interface CursoResponseDto {
 }
 
 export interface CursoRequestDto {
-  anioCursado: number;
+  anioCursado?: number;
   division: string;
   anioAcademicoId: number;
 }


### PR DESCRIPTION
## Summary
- reorganiza el menu lateral creando secciones de Administración y Académico

## Testing
- `npm run build` *(falla: `ng` no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_684e04655a58832fa328da5c2056774e